### PR TITLE
fix partition parse when a disk mounted directly

### DIFF
--- a/pkg/lsblk/partition.go
+++ b/pkg/lsblk/partition.go
@@ -44,7 +44,7 @@ func (lsb LSBlk) partitionInfo() ([]manager.PartitionInfo, error) {
 		devicePath = lsb.Name
 	}
 
-	output, err := utils.Bash(fmt.Sprintf("lsblk %s --bytes --pairs --output NAME,SIZE,TYPE,PKNAME", devicePath))
+	output, err := utils.Bash(fmt.Sprintf("lsblk %s --bytes --pairs --output NAME,SIZE,TYPE,PKNAME,FSTYPE", devicePath))
 	if err != nil {
 		return nil, err
 	}
@@ -54,9 +54,11 @@ func (lsb LSBlk) partitionInfo() ([]manager.PartitionInfo, error) {
 		props := utils.ParseKeyValuePairString(item)
 		switch props["NAME"] {
 		case lsb.Name:
-			_, err = strconv.ParseUint(props["SIZE"], 10, 64)
-			if err != nil {
-				return nil, err
+			if props["FSTYPE"] != "" {
+				partitions = append(partitions, manager.PartitionInfo{
+					Name: lsb.Name,
+					Filesystem: props["FSTYPE"] ,
+				})
 			}
 
 		default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### Why we need this PR:
fix https://github.com/hwameistor/local-disk-manager/issues/33

when a disk was mounted directly, the partition information in the corresponding LD resource will show errors, and the description of the partition info is missing.

##### How to resolve
add `FSTYPE` flag when parse a disk by lsblk

#### Special notes for your reviewer:
NONE
#### Does this PR introduce a user-facing change?
```release-note
NONE
```
