### PR TITLE
refactor: update disk reserved logic by extending reserve extend-point

### DIFF
--- a/pkg/controller/localdiskvolume/localdiskvolume_controller.go
+++ b/pkg/controller/localdiskvolume/localdiskvolume_controller.go
@@ -336,6 +336,13 @@ func (v *DiskVolumeHandler) MountFileSystem(devPath, mountPoint, fsType string, 
 
 func (v *DiskVolumeHandler) UnMount(mountPoint string) error {
 	if err := v.mounter.Unmount(mountPoint); err != nil {
+		// fixme: need consider raw block
+		if !v.IsDevMountPoint(mountPoint) {
+			v.RecordEvent(corev1.EventTypeWarning, "UnMountSuccess", "Unmount skipped due to mountpoint %s is empty or not mounted by disk %s",
+				mountPoint, v.ldv.Status.DevPath)
+			return nil
+		}
+
 		v.RecordEvent(corev1.EventTypeWarning, "UnMountFailed", "Failed to umount %s due to err: %v",
 			mountPoint, err)
 		return err
@@ -344,6 +351,16 @@ func (v *DiskVolumeHandler) UnMount(mountPoint string) error {
 	v.RecordEvent(corev1.EventTypeNormal, "UnMountSuccess", "Unmount %s successfully",
 		mountPoint)
 	return nil
+}
+
+// IsDevMountPoint judge if this mountpoint is mounted by the dev
+func (v *DiskVolumeHandler) IsDevMountPoint(mountPoint string) bool {
+	for _, p := range v.mounter.GetDeviceMountPoints(v.ldv.Status.DevPath) {
+		if p == mountPoint {
+			return true
+		}
+	}
+	return false
 }
 
 func (v *DiskVolumeHandler) VolumeState() ldm.State {

--- a/pkg/csi/diskmanager/diskmanager.go
+++ b/pkg/csi/diskmanager/diskmanager.go
@@ -41,14 +41,20 @@ type DiskManager interface {
 	GetNodeDisks(node string) ([]*Disk, error)
 
 	// ClaimDisk UpdateDiskStatus mark disk to TobeMount/Free/InUse... status
-	ClaimDisk(*Disk) error
+	ClaimDisk(name string) error
 
-	// ReleaseDisk update disk to release status
-	ReleaseDisk(diskName string) error
+	// FilterFreeDisks filter matchable free disks
+	FilterFreeDisks([]Disk) (bool, error)
 
-	// SelectFreeDisk use a disk and bind it to a volume
-	SelectFreeDisk(Disk) (*Disk, error)
+	// ReserveDiskForVolume reserve a disk for the volume
+	ReserveDiskForVolume(disk Disk, volume string) error
 
-	// PreSelectFreeDisks only reserve disks, but not use
-	PreSelectFreeDisks([]Disk) (bool, error)
+	// UnReserveDiskForPVC update related disk to release status
+	UnReserveDiskForPVC(pvc string) error
+
+	// ReleaseDisk setup disk to release status
+	ReleaseDisk(disk string) error
+
+	// GetReservedDiskByPVC get disk reserved by the volume
+	GetReservedDiskByPVC(pvc string) (*Disk, error)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### Why we need this PR:
Optimize the disk reservation mechanism through the **reserve extension** point of the scheduler

#### Special notes for your reviewer:
related issue:https://github.com/hwameistor/local-disk-manager/issues/55
#### Does this PR introduce a user-facing change?
```release-note

```
